### PR TITLE
Fix namecheap lock status

### DIFF
--- a/classes/NamecheapClient.php
+++ b/classes/NamecheapClient.php
@@ -75,7 +75,7 @@ class NameCheapClient implements RegistrarClient {
             $qs2 = http_build_query($queryData2);
             $url2 = "{$this->server}{$this->apiEndpoint}?$qs2";
             $xml2 = simplexml_load_file($url2);
-            return (string)$xml2->CommandResponse->DomainGetRegistrarLockResult->attributes()->RegistrarLockStatus === 'true'? true: false;
+            return (string)($xml2->CommandResponse->DomainGetRegistrarLockResult->attributes()->RegistrarLockStatus) === 'true';
     }
 
     public function SupportsDnsSec() : bool {

--- a/classes/NamecheapClient.php
+++ b/classes/NamecheapClient.php
@@ -57,11 +57,17 @@ class NameCheapClient implements RegistrarClient {
         $domainlist = [];
         foreach($domainlistXML as $domain) {
             $attributes = $domain->attributes();
+            $queryData2 = $this->baseApiArgs('namecheap.domains.getRegistrarLock');
+            $queryData2['DomainName'] = urlencode($attributes->Name);
+            $qs2 = http_build_query($queryData2);
+            $url2 = "{$this->server}{$this->apiEndpoint}?$qs2";
+            $xml2 = simplexml_load_file($url2);
+            $domainlocked = $xml2->CommandResponse->DomainGetRegistrarLockResult->attributes()->RegistrarLockStatus;
 
             $d = new Domain();
             $d->registrar = 'Namecheap';
             $d->name = $attributes->Name;
-            $d->locked = ($attributes->IsLocked == 'true');
+            $d->locked = ($domainlocked == 'true');
             $d->expires = $attributes->Expires;
             $d->autorenew = ($attributes->AutoRenew == 'true');
             $domainlist []= $d;

--- a/classes/NamecheapClient.php
+++ b/classes/NamecheapClient.php
@@ -57,22 +57,25 @@ class NameCheapClient implements RegistrarClient {
         $domainlist = [];
         foreach($domainlistXML as $domain) {
             $attributes = $domain->attributes();
-            $queryData2 = $this->baseApiArgs('namecheap.domains.getRegistrarLock');
-            $queryData2['DomainName'] = urlencode($attributes->Name);
-            $qs2 = http_build_query($queryData2);
-            $url2 = "{$this->server}{$this->apiEndpoint}?$qs2";
-            $xml2 = simplexml_load_file($url2);
-            $domainlocked = $xml2->CommandResponse->DomainGetRegistrarLockResult->attributes()->RegistrarLockStatus;
-
             $d = new Domain();
             $d->registrar = 'Namecheap';
             $d->name = $attributes->Name;
-            $d->locked = ($domainlocked == 'true');
+            $d->locked = $this->DomainLocked($attributes->Name);
             $d->expires = $attributes->Expires;
             $d->autorenew = ($attributes->AutoRenew == 'true');
             $domainlist []= $d;
         }
         return $domainlist;
+    }
+
+    // will return string true if domain is locked, false if domain is unlocked
+    private function DomainLocked(string $domain) : bool {
+            $queryData2 = $this->baseApiArgs('namecheap.domains.getRegistrarLock');
+            $queryData2['DomainName'] = urlencode($domain);
+            $qs2 = http_build_query($queryData2);
+            $url2 = "{$this->server}{$this->apiEndpoint}?$qs2";
+            $xml2 = simplexml_load_file($url2);
+            return (string)$xml2->CommandResponse->DomainGetRegistrarLockResult->attributes()->RegistrarLockStatus === 'true'? true: false;
     }
 
     public function SupportsDnsSec() : bool {


### PR DESCRIPTION
This fixes the NameCheap lock status by calling namecheap.domains.getRegistrarLock for each domain.  @lfkeitel do you think this is a good way to do it, or do I need to make a new function to get lock status?